### PR TITLE
Fix error with Rails 3.2.13/14 Pathname -> String

### DIFF
--- a/lib/opbeat/event.rb
+++ b/lib/opbeat/event.rb
@@ -179,8 +179,8 @@ module Opbeat
     end
 
     def strip_load_path_from(path)
-      prefix = $:.select {|s| path.start_with?(s)}.sort_by {|s| s.length}.last
-      prefix ? path[prefix.chomp(File::SEPARATOR).length+1..-1] : path
+      prefix = $:.select {|s| path.start_with?(s.to_s)}.sort_by {|s| s.to_s.length}.last
+      prefix ? path[prefix.to_s.chomp(File::SEPARATOR).length+1..-1] : path
     end
   end
 end


### PR DESCRIPTION
This fixes #3 in the dumbest way possible.
