### PR TITLE
Fixed example typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Opbeat.configure do |config|
   config.app_id = '094e250818'
   config.secret_token = 'f0f5237a221637f561a15614f5fef218f8d6317d'
   
-  config.processors = [Opbeat::Processors::SanitizeData]
+  config.processors = [Opbeat::Processor::SanitizeData]
 end
 ```
 


### PR DESCRIPTION
First I thought the processor was just an example. Digging through the code for examples I noticed it was just a typo :-)
