### PR TITLE
resque integration

### DIFF
--- a/lib/opbeat/integrations/resque.rb
+++ b/lib/opbeat/integrations/resque.rb
@@ -1,0 +1,22 @@
+begin
+  require 'resque'
+rescue LoadError
+end
+
+if defined?(Resque)
+
+  module Resque
+    module Failure
+      # Failure backend for Opbeat
+      class Opbeat < Base
+        # @override (see Resque::Failure::Base#save)
+        # @param (see Resque::Failure::Base#save)
+        # @return (see Resque::Failure::Base#save)
+        def save
+          ::Opbeat.captureException(exception)
+        end
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
This is the bare minimum Resque integration.  

There is a lot of additional metadata available, like `queue`, `args`, etc but `captureException` cannot currently accept them. 
