### PR TITLE
Fixes capistrano task and rails integration

### DIFF
--- a/lib/opbeat/capistrano/capistrano3.rb
+++ b/lib/opbeat/capistrano/capistrano3.rb
@@ -18,28 +18,6 @@ namespace :opbeat do
         end
       end
     end
-
-      # within repo_path do
-      #   rev = fetch(:current_revision)
-
-      #   branches = capture("cd #{repo_path}; /usr/bin/env git branch --contains #{rev}").split
-      #   if branches.length == 1
-      #     branch = branches[0].sub("* ", "")
-      #   else
-      #     branch = nil
-      #   end
-
-      #   notify_command = "REV=#{rev} "
-      #   notify_command << "BRANCH=#{branch} " if branch
-
-      #   rails_env = fetch(:rails_env, "production")
-      #   notify_command << "RAILS_ENV=#{rails_env} "
-
-      #   executable = fetch(:rake, 'bundle exec rake ')
-      #   notify_command << "#{executable} opbeat:deployment"
-      #   capture ("cd #{release_path};" + notify_command), :once => true
-      # end
-    # end
   end
 end
 

--- a/lib/opbeat/client.rb
+++ b/lib/opbeat/client.rb
@@ -17,7 +17,7 @@ module Opbeat
 
     def should_try?
       return true if @status == :online
-        
+
       interval = ([@retry_number, 6].min() ** 2) * @configuration[:backoff_multiplier]
       return true if Time.now - @last_check > interval
 
@@ -79,11 +79,11 @@ module Opbeat
 
     def encode(event)
       event_hash = event.to_hash
-      
+
       @processors.each do |p|
         event_hash = p.process(event_hash)
       end
-      
+
       return MultiJson.encode(event_hash)
     end
 
@@ -95,7 +95,7 @@ module Opbeat
           req.headers[AUTH_HEADER_KEY] = self.generate_auth_header(req.body)
           req.headers["User-Agent"] = USER_AGENT
         end
-        unless !response.status.between?(200, 299)
+        if !response.status.between?(200, 299)
           raise Error.new("Error from Opbeat server (#{response.status}): #{response.body}")
         end
       rescue


### PR DESCRIPTION
The previous implementation didn't handle rvm and bundler in the best way (by using capistrano-rvm, instead of assuming that bundler is already on PATH)

There was also a problem with a double negative in the client, meaning that any successfull release would trigger an error, instead of the oposite
