### PR TITLE
Add Opbeat.capture_rack_exception

### DIFF
--- a/lib/opbeat.rb
+++ b/lib/opbeat.rb
@@ -101,6 +101,17 @@ module Opbeat
       end
     end
 
+    def capture_rack_exception(exception, env, options={})
+      exception.set_backtrace caller unless exception.backtrace
+      if (evt = Event.from_rack_exception(exception, env, options))
+        if self.configuration.async?
+          self.configuration.async.call(evt)
+        else
+          send(evt)
+        end
+      end
+    end
+
     def capture_message(message, options={})
       if (evt = Event.from_message(message, caller, options))
         if self.configuration.async?

--- a/lib/opbeat/rack.rb
+++ b/lib/opbeat/rack.rb
@@ -28,16 +28,14 @@ module Opbeat
       rescue Error => e
         raise # Don't capture Opbeat errors
       rescue Exception => e
-        evt = Event.from_rack_exception(e, env)
-        Opbeat.send(evt)
+        Opbeat.capture_rack_exception(e, env)
         raise
       end
 
       error = env['rack.exception'] || env['sinatra.error']
 
       if error
-        evt = Event.from_rack_exception(error, env)
-        Opbeat.send(evt) if evt
+        Opbeat.capture_rack_exception(error, env)
       end
 
       response

--- a/opbeat.gemspec
+++ b/opbeat.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ["README.md", "LICENSE"]
 
   gem.add_dependency "faraday", [">= 0.7.6", "< 0.10"]
-  gem.add_dependency "multi_json", "~> 1.0"
+  gem.add_dependency "multi_json", "~> 1.12.1"
 
   gem.add_development_dependency "bundler", "~> 1.7"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/spec/opbeat/opbeat_spec.rb
+++ b/spec/opbeat/opbeat_spec.rb
@@ -8,6 +8,7 @@ describe Opbeat do
     allow(Opbeat).to receive(:send) { @send }
     allow(Opbeat::Event).to receive(:from_message) { @event }
     allow(Opbeat::Event).to receive(:from_exception) { @event }
+    allow(Opbeat::Event).to receive(:from_rack_exception) { @event }
   end
 
   it 'capture_message should send result of Event.from_message' do
@@ -34,6 +35,26 @@ describe Opbeat do
     expect(Opbeat).to receive(:send).with(@event)
 
     Opbeat.capture_exception(exception)
+  end
+
+  it 'capture_rack_exception should send result of Event.from_exception built with env and default options' do
+    exception = build_exception()
+    rack_env = build_rack_env()
+
+    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, rack_env, {})
+    expect(Opbeat).to receive(:send).with(@event)
+
+    Opbeat.capture_rack_exception(exception, rack_env)
+  end
+
+  it "capture_rack_exception should send result of Event.from_exception built with env and options" do
+    exception = build_exception()
+    rack_env = build_rack_env()
+
+    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, rack_env, {:custom => :param})
+    expect(Opbeat).to receive(:send).with(@event)
+
+    Opbeat.capture_rack_exception(exception, rack_env, {:custom => :param})
   end
 
   context "async" do

--- a/spec/opbeat/opbeat_spec.rb
+++ b/spec/opbeat/opbeat_spec.rb
@@ -58,6 +58,10 @@ describe Opbeat do
   end
 
   context "async" do
+    after do
+      Opbeat.configuration.async = false
+    end
+
     it 'capture_message should send result of Event.from_message' do
       async = lambda {}
       message = "Test message"

--- a/spec/opbeat/rack_spec.rb
+++ b/spec/opbeat/rack_spec.rb
@@ -41,9 +41,8 @@ describe Opbeat::Rack do
   it 'should capture exceptions' do
     exception = build_exception()
     env = {}
-    
-    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, env)
-    expect(Opbeat).to receive(:send).with(@event)
+
+    expect(Opbeat).to receive(:capture_rack_exception).with(exception, env)
 
     app = lambda do |e|
       raise exception
@@ -57,8 +56,7 @@ describe Opbeat::Rack do
     exception = build_exception()
     env = {}
 
-    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, env)
-    expect(Opbeat).to receive(:send).with(@event)
+    expect(Opbeat).to receive(:capture_rack_exception).with(exception, env)
 
     app = lambda do |e|
       e['rack.exception'] = exception

--- a/spec/opbeat/rack_spec.rb
+++ b/spec/opbeat/rack_spec.rb
@@ -35,14 +35,14 @@ describe Opbeat::Rack do
     @send = double("send")
     @event = double("event")
     allow(Opbeat).to receive(:send) { @send }
-    allow(Opbeat::Event).to receive(:from_rack_exception) { @event }
   end
 
   it 'should capture exceptions' do
     exception = build_exception()
     env = {}
 
-    expect(Opbeat).to receive(:capture_rack_exception).with(exception, env)
+    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, env, {}) { @event }
+    expect(Opbeat).to receive(:send).with(@event)
 
     app = lambda do |e|
       raise exception
@@ -56,7 +56,8 @@ describe Opbeat::Rack do
     exception = build_exception()
     env = {}
 
-    expect(Opbeat).to receive(:capture_rack_exception).with(exception, env)
+    expect(Opbeat::Event).to receive(:from_rack_exception).with(exception, env, {}) { @event }
+    expect(Opbeat).to receive(:send).with(@event)
 
     app = lambda do |e|
       e['rack.exception'] = exception

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,15 @@ def build_exception()
     return exception
   end
 end
+
+def build_rack_env()
+  {
+    "QUERY_STRING" => "a=1&b=2",
+    "REMOTE_ADDR" => "::1",
+    "REMOTE_HOST" => "localhost",
+    "REQUEST_METHOD" => "GET",
+    "REQUEST_PATH" => "/index.html",
+    "HTTP_HOST" => "localhost:3000",
+    "HTTP_VERSION" => "HTTP/1.1"
+  }
+end


### PR DESCRIPTION
Currently I'm handling all exceptions at application level in order to properly format them and return proper response codes (400 vs 500).

https://github.com/intridea/grape#exception-handling

Since the `Opbeat::Rack` middleware is put before my `Grape` middleware and since the `Grape` middleware is catching the errors and formatting them, the errors will never arrive in `Opbeat::Rack` middleware.

This PR adds a method named `capture_rack_exception`, which allows to also pass the rack environment.

I also changed how `Opbeat::Rack` sends errors, passing them through this method, also allowing for `async` behaviour.

This method was extracted from our codebase, we are using this method in production as a monkey patch for a few months.
