### PR TITLE
Sidekiq: capture sidekiq context as extra info

### DIFF
--- a/lib/opbeat/integrations/sidekiq.rb
+++ b/lib/opbeat/integrations/sidekiq.rb
@@ -12,7 +12,7 @@ if defined? Sidekiq
             yield
           rescue Exception => ex
             raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-            ::Opbeat.capture_exception(ex)
+            ::Opbeat.capture_exception(ex, extra: msg)
             raise
           end
         end
@@ -26,7 +26,7 @@ if defined? Sidekiq
         chain.add ::Opbeat::Integrations::Sidekiq
       end
     else
-      config.error_handlers << Proc.new { |ex, ctx| ::Opbeat.capture_exception(ex) }
+      config.error_handlers << Proc.new { |ex, ctx| ::Opbeat.capture_exception(ex, extra: ctx) }
     end
   end
 end


### PR DESCRIPTION
The Sidekiq context contains some very useful things for debugging purposes, for instance:
- ID of the failed job
- arguments for the job
- name of the worker class

Side note: should support for Sidekiq v2 be dropped? Version 4 was just released, and the latest version 2 release is over a year old already.
