### PR TITLE
Send Sidekiq context into Opbeat

### DIFF
--- a/lib/opbeat/integrations/sidekiq.rb
+++ b/lib/opbeat/integrations/sidekiq.rb
@@ -26,7 +26,7 @@ if defined? Sidekiq
         chain.add ::Opbeat::Integrations::Sidekiq
       end
     else
-      config.error_handlers << Proc.new { |ex, ctx| ::Opbeat.capture_exception(ex) }
+      config.error_handlers << Proc.new { |ex, ctx| ::Opbeat.capture_exception(ex, extra: ctx) }
     end
   end
 end


### PR DESCRIPTION
Sends Sidekiq's context into Opbeat for easier debugging.

Here's an example of the data it shows:

<img width="959" alt="screenshot 2015-12-04 12 03 25" src="https://cloud.githubusercontent.com/assets/218910/11579081/0d8c7162-9a7f-11e5-899c-22714a2ec994.png">
